### PR TITLE
feat(npm): use "npm-run-all" for npm test

### DIFF
--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "eslint:md": "eslint -c .md.eslintrc --ext .md ja/**/*.md",
     "textlint": "summary-to-path | xargs textlint --rule spellcheck-tech-word",
     "test:example": "find ./src -name '*-example.js' | xargs babel-node",
-    "test": "mocha && npm run test:example && npm run textlint && npm run eslint:md && npm run eslint && npm run build"
+    "test:js": "mocha",
+    "test": "npm-run-all --parallel test:js test:example textlint eslint:md eslint build"
   },
   "keywords": [
     "plugin",
@@ -41,6 +42,7 @@
     "gitbook-summary-to-path": "^1.0.1",
     "jsdom": "^3.0.0",
     "mocha": "^2.2.5",
+    "npm-run-all": "^1.2.8",
     "power-assert": "^1.0.0",
     "textlint": "^3.2.0",
     "textlint-rule-spellcheck-tech-word": "^4.0.1"


### PR DESCRIPTION
use [npm-run-all --parallel](https://github.com/mysticatea/npm-run-all "npm-run-all --parallel") for `npm test` via [npm-run-all と concurrently を試す | アカベコマイリ](http://akabeko.me/blog/2015/08/npm-run-all-and-concurrently/ "npm-run-all と concurrently を試す | アカベコマイリ").

## Before

```sh
$ time npm test
npm test  11.06s user 1.41s system 99% cpu 12.520 total
```

## After

```sh
$ time npm test
npm test  14.87s user 1.79s system 387% cpu 4.302 total
```