### PR TITLE
chore: summaryのリンクをconnectからConnectに修正

### DIFF
--- a/SUMMARY.md
+++ b/SUMMARY.md
@@ -4,5 +4,5 @@
 * [Introduction](ja/introduction/README.md)
 * [jQuery](ja/jQuery/README.md)
 * [ESLint](ja/ESLint/README.md)
-* [connect](ja/connect/README.md)
+* [Connect](ja/connect/README.md)
 


### PR DESCRIPTION
Related: 5e9f72e (#48)

Because textlint-rule-prh skips child nodes of a Syntax.Link node, this is not pointed out by `npm test`.