### PR TITLE
Travis CIにキャッシュの設定を追加

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 sudo: false
 language: node_js
 node_js: "stable"
+cache:
+  directories:
+    - node_modules
 after_script:
   - npm run-script coveralls


### PR DESCRIPTION
node_modulesをキャッシュするようにした

- [The Travis CI Blog: Speed Up Your Builds: Cache Your Dependencies](http://blog.travis-ci.com/2013-12-05-speed-up-your-builds-cache-your-dependencies/ "The Travis CI Blog: Speed Up Your Builds: Cache Your Dependencies")