### PR TITLE
textlint: unexpected-acronymの検出を追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,9 +37,17 @@ JavaScriptの世界では1つの大きなライブラリよりも小さいなも
 
 [textlint](https://github.com/textlint/textlint "textlint")と[textlint-formatter-codecov](https://github.com/azu/textlint-formatter-codecov "textlint-formatter-codecov")を使って出してる文章に対するカバレッジ
 
+100％を理想的目標として、それに対する現実的な値をカバレッジの％として表現しています。
+
 [![codecov.io](https://codecov.io/github/azu/JavaScript-Plugin-Architecture/coverage.svg?branch=master)](https://codecov.io/github/azu/JavaScript-Plugin-Architecture?branch=master)
 
 ![coverage graph](https://codecov.io/github/azu/JavaScript-Plugin-Architecture/branch.svg?branch=master)
+
+現在の文章カバレッジは以下のコマンドでも確認することができます。
+
+```
+npm run textlint:coverage
+```
 
 ## Contributing
 

--- a/coverage.textlintrc
+++ b/coverage.textlintrc
@@ -5,6 +5,7 @@
       "max": 3,
       "strict": true
     },
+    "unexpanded-acronym": true,
     "no-double-negative-ja": true,
     "no-doubled-joshi": {
       "min_interval": 1,

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:js": "mocha",
     "test": "npm-run-all --parallel test:js test:example textlint eslint:md eslint build",
     "textlint:strict": "summary-to-path | xargs textlint -c coverage.textlintrc",
-    "textlint:coverage": "npm run textlint:strict -- -f lcov | lcov-summary",
+    "textlint:coverage": "summary-to-path | xargs textlint -c coverage.textlintrc -f lcov | lcov-summary",
     "travis:coverage": "summary-to-path | xargs textlint -c coverage.textlintrc -f codecov | codecov"
   },
   "keywords": [

--- a/package.json
+++ b/package.json
@@ -39,7 +39,6 @@
   "devDependencies": {
     "babel-cli": "^6.3.13",
     "babel-preset-es2015": "^6.3.13",
-    "codecov-json-to-lcov": "^1.1.1",
     "codecov.io": "^0.1.6",
     "connect": "^3.4.0",
     "eslint": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "test:js": "mocha",
     "test": "npm-run-all --parallel test:js test:example textlint eslint:md eslint build",
     "textlint:strict": "summary-to-path | xargs textlint -c coverage.textlintrc",
+    "textlint:coverage": "npm run textlint:strict -- -f lcov | lcov-summary",
     "travis:coverage": "summary-to-path | xargs textlint -c coverage.textlintrc -f codecov | codecov"
   },
   "keywords": [
@@ -38,6 +39,7 @@
   "devDependencies": {
     "babel-cli": "^6.3.13",
     "babel-preset-es2015": "^6.3.13",
+    "codecov-json-to-lcov": "^1.1.1",
     "codecov.io": "^0.1.6",
     "connect": "^3.4.0",
     "eslint": "^1.3.0",
@@ -52,6 +54,7 @@
     "gitbook-plugin-richquotes": "0.0.7",
     "gitbook-summary-to-path": "^1.0.1",
     "jsdom": "^7.0.1",
+    "lcov-summary": "^1.0.1",
     "mdast": "^2.1.0",
     "mocha": "^2.2.5",
     "nlcst-to-string": "^1.0.0",
@@ -61,6 +64,7 @@
     "stemming-x-keywords": "^1.0.3",
     "textlint": "^5.2.0",
     "textlint-formatter-codecov": "^1.0.2",
+    "textlint-formatter-lcov": "^1.0.2",
     "textlint-rule-max-ten": "^2.0.0",
     "textlint-rule-no-double-negative-ja": "^1.0.2",
     "textlint-rule-no-doubled-joshi": "^2.0.0",
@@ -70,6 +74,7 @@
     "textlint-rule-prh": "^2.0.0",
     "textlint-rule-sentence-length": "^1.0.4",
     "textlint-rule-spellcheck-tech-word": "^4.0.1",
+    "textlint-rule-unexpanded-acronym": "^1.2.0",
     "unist-util-is": "^1.0.0",
     "unist-util-parents": "^0.1.1",
     "unist-util-select": "^1.0.0"


### PR DESCRIPTION
textlint:strictの方のみに追加した。

- https://github.com/azu/textlint-rule-unexpanded-acronym

OSSやCONTRIBUTINGなどわざわざ書く必要ないものもあるためとりあえず。


またカバレッジの確認方法もREADMEに追加。