### PR TITLE
Fix typos in connect

### DIFF
--- a/ja/connect/README.md
+++ b/ja/connect/README.md
@@ -23,7 +23,7 @@ Echoサーバとは、送られてきたリクエストの内容をそのまま�
 ```
 
 `app.use(middleware)` という形で、 _middleware_ と呼ばれる関数には`request`や`response`といったオブジェクトが渡されます。
-この`request`や`response`を _middleware_ で処理してログを取ったり、任意のレスポンスを返したりできるようになっています。
+この`request`や`response`を _middleware_ で処理することで、ログを取ったり、任意のレスポンスを返すことができます。
 
 Echoサーバでは `req.pipe(res);` という形でリクエストをそのままレスポンスとして流す事で実現されています。
 

--- a/ja/connect/README.md
+++ b/ja/connect/README.md
@@ -23,7 +23,7 @@ Echoサーバとは、送られてきたリクエストの内容をそのまま�
 ```
 
 `app.use(middleware)` という形で、 _middleware_ と呼ばれる関数には`request`や`response`といったオブジェクトが渡されます。
-この`request`や`response`を _middleware_ で処理してログを取ったり、任意のレスポンスを返しことができるようになっています。
+この`request`や`response`を _middleware_ で処理してログを取ったり、任意のレスポンスを返したりできるようになっています。
 
 Echoサーバでは `req.pipe(res);` という形でリクエストをそのままレスポンスとして流す事で実現されています。
 

--- a/ja/connect/README.md
+++ b/ja/connect/README.md
@@ -171,7 +171,7 @@ Connect自体の機能は少ないですが、その分 _middleware_ の種類�
 
 また、それぞれの _middleware_ が小さな単機能となっていて、それを組み合わせて使うように作られているケースが多いです。
 
-これは、 _middleware_ が層として重なっている作り、つまり _middleware stack_ の形を取ることが多いだと言えます。
+これは、 _middleware_ が層として重なっている作り、つまり _middleware stack_ の形を取ることが多いためだと言えます。
 
 ![pylons_as_onion](img/pylons_as_onion.png)
 


### PR DESCRIPTION
https://github.com/azu/JavaScript-Plugin-Architecture/commit/8575e171ade98fe7a1f64b96bd6156f1125602be は`返すことができる`と直すほうがシンプルですが、文の流れを考えると`返したりできる`と直すほうが良いと思いました。